### PR TITLE
FIX: Version of react-router must be at least 2.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "dependencies": {},
   "peerDependencies": {
     "react": ">=0.14.0",
-    "react-router": "2.x"
+    "react-router": "^2.4.0"
   },
   "devDependencies": {
     "eslint-config-jonnybuchanan": "3.2.1",


### PR DESCRIPTION
in `/lib/index.js`  the file `react-router/lib/withRouter` is required. this was introduced in `react-router@2.4.0`
